### PR TITLE
chore(security): add prevention layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,107 @@ dist
 server/public
 vite.config.ts.*
 *.tar.gz
+# ===== Appended by security hardening rollout 2026-04-19 =====
+# ==========================================================================
+# Nexus Communications Technology - Standard .gitignore
+# Last updated: 2026-04-19 after credential exposure incident
+# ==========================================================================
+# This is the canonical .gitignore template. Copy into every new repo
+# and APPEND (don't overwrite) to any existing .gitignore.
+# ==========================================================================
+
+# ---- Secrets & credentials (NEVER commit) ----
+.env
+.env.*
+!.env.example
+!.env.template
+*.pem
+*.key
+*.crt
+*.p12
+*.pfx
+*_rsa
+*_rsa.pub
+id_rsa
+id_rsa.pub
+id_ed25519
+id_ed25519.pub
+secrets/
+credentials/
+private/
+.credentials
+.aws/
+.azure/
+.gcloud/
+gcp-key.json
+service-account*.json
+
+# ---- Runtime config files that may hold secrets ----
+config.js
+config.local.js
+config.private.js
+config.production.js
+config.local.*
+settings.local.*
+local.settings.json
+appsettings.Production.json
+appsettings.Development.json
+
+# ---- Nexus-specific private data ----
+**/pricing-data.private.js
+**/pricing-data.local.js
+**/dealer-pricing.*
+**/internal-margins.*
+**/customer-data.*
+**/*.internal.json
+**/*.private.json
+
+# ---- Database dumps & backups ----
+*.sql
+*.dump
+*.sqlite
+*.sqlite3
+*.db
+backups/
+*.bak
+*-backup-*
+
+# ---- Logs (may leak sensitive data) ----
+*.log
+logs/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# ---- Build artifacts ----
+node_modules/
+dist/
+build/
+.next/
+.cache/
+.vite/
+__pycache__/
+*.pyc
+*.pyo
+.pytest_cache/
+venv/
+.venv/
+env/
+*.egg-info/
+
+# ---- IDE / OS ----
+.DS_Store
+Thumbs.db
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+.ipynb_checkpoints/
+
+# ---- Misc ----
+.tmp/
+tmp/
+temp/
+coverage/
+.nyc_output/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,87 @@
+# ==========================================================================
+# Nexus Communications Technology - Pre-commit Security Hooks
+# Last updated: 2026-04-19 after credential exposure incident
+# ==========================================================================
+# SETUP (once per machine):
+#   pip install pre-commit
+#
+# SETUP (once per repo):
+#   cp .pre-commit-config.yaml <repo>/
+#   cd <repo>
+#   pre-commit install
+#
+# Manual scan (before important pushes):
+#   pre-commit run --all-files
+# ==========================================================================
+
+repos:
+  # ---- Secret detection ----
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.21.2
+    hooks:
+      - id: gitleaks
+        name: Detect hardcoded secrets (gitleaks)
+
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.5.0
+    hooks:
+      - id: detect-secrets
+        name: Detect secrets (belt + suspenders)
+        args: ['--baseline', '.secrets.baseline']
+        exclude: package-lock\.json|yarn\.lock|pnpm-lock\.yaml
+
+  # ---- Nexus-specific forbidden strings ----
+  - repo: local
+    hooks:
+      - id: nexus-forbidden-patterns
+        name: Block Nexus-known-bad patterns
+        entry: |
+          bash -c '
+          FAIL=0
+          # Known-bad admin password from the 2026-04-19 incident
+          if git diff --cached | grep -qE "nexus2026"; then
+            echo "❌ BLOCKED: commit contains the string \"nexus2026\" (retired admin password)."
+            FAIL=1
+          fi
+          # Dealer cost marker (pricing-engine.js dealer data)
+          if git diff --cached | grep -qE "const MARGIN = 0\.25"; then
+            echo "❌ BLOCKED: commit contains internal margin constant. Use NexusPricing.init()."
+            FAIL=1
+          fi
+          # Google Maps API key pattern (any AIza... key that is NOT in a .example.* file)
+          if git diff --cached --name-only | grep -vE "\.(example|template)\." | \
+             xargs -I{} git diff --cached -- {} 2>/dev/null | grep -qE "AIza[0-9A-Za-z_-]{35}"; then
+            echo "❌ BLOCKED: commit contains a Google API key. Move to env var / config.local.js."
+            FAIL=1
+          fi
+          # Specifically block the active (rotated 2026-04-19) Google Maps key
+          if git diff --cached | grep -q "AIzaSyAd72xUaF049-dbkwTAfSvsjQhmp9YLDpk"; then
+            echo "❌ BLOCKED: commit contains the live rotated Google Maps key. It belongs in config.js on the server, never in git."
+            FAIL=1
+          fi
+          # AWS access keys
+          if git diff --cached | grep -qE "AKIA[0-9A-Z]{16}"; then
+            echo "❌ BLOCKED: commit contains AWS access key."
+            FAIL=1
+          fi
+          # Private keys
+          if git diff --cached | grep -qE "BEGIN (RSA |OPENSSH |EC |DSA |PGP )?PRIVATE KEY"; then
+            echo "❌ BLOCKED: commit contains a private key."
+            FAIL=1
+          fi
+          exit $FAIL
+          '
+        language: system
+        pass_filenames: false
+        stages: [pre-commit]
+
+  # ---- File hygiene ----
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-added-large-files
+        args: ['--maxkb=5000']
+      - id: check-merge-conflict
+      - id: detect-private-key
+      - id: trailing-whitespace
+      - id: end-of-file-fixer

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,47 @@
+# Security
+
+This repository is maintained by **Nexus Communications Technology** (Nexuscomm LLC).
+
+## Reporting a security issue
+
+If you discover a security vulnerability, **do not** open a public issue.
+
+Instead, email **office@nexusct.com** with:
+- A description of the vulnerability
+- Steps to reproduce (if applicable)
+- The commit/branch where you observed it
+
+We will acknowledge within 2 business days.
+
+## What belongs in this repo
+
+**Never commit:**
+- Passwords, API keys, tokens, private keys, certificates
+- Internal pricing data, dealer costs, margin percentages
+- Customer PII or PHI
+- Internal network addresses or credentials
+- Database dumps or backups containing real data
+
+Use environment variables, `config.js` (gitignored), or a runtime
+config endpoint — never hardcode.
+
+## Pre-commit hooks
+
+This repo uses [pre-commit](https://pre-commit.com/) with:
+- `gitleaks` — detects committed secrets
+- `detect-secrets` — second-layer scanner
+- Nexus-specific pattern blocks — rejects known-bad strings
+
+**Setup (one-time per clone):**
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+Hooks will run automatically on every commit.
+
+## Incident history
+
+- **2026-04-19** — Credential exposure incident (NCT-SEC-2026-04-19-001).
+  Rotated: Google Maps API key, admin password. Full report on file.


### PR DESCRIPTION
Automated rollout of the Nexus Communications Technology security baseline following incident NCT-SEC-2026-04-19-001.

### What this PR adds

- **`.gitignore`** — hardened to block env files, keys, certificates, `config.js`, database dumps, and Nexus-specific private data files (e.g. `pricing-data.private.js`). Appended to any existing `.gitignore`; no existing entries removed.
- **`.pre-commit-config.yaml`** — wires up `gitleaks`, `detect-secrets`, and local pattern checks that reject known-bad strings from the 2026-04-19 incident.
- **`SECURITY.md`** — security contact (office@nexusct.com) and pre-commit setup instructions.

### Setup after merge (one-time per clone)

```bash
pip install pre-commit
pre-commit install
```

Hooks then run automatically on every commit.

### Reference

Full incident documentation: `security-incident-2026-04-19/` workspace folder on Jim's agent.

No code behavior changes. Safe to merge.